### PR TITLE
APP-4260 Changed the error handling logic to throw error.

### DIFF
--- a/src/gremlinclient.js
+++ b/src/gremlinclient.js
@@ -48,6 +48,7 @@ function GremlinClient(port, host, options) {
 
 	  this.ws.onerror = function(e) {
 		console.log('Error:', e);
+        throw e;
 	  };
 
 	  this.ws.onmessage = this.handleMessage.bind(this);


### PR DESCRIPTION
By doing this the titanService detects that there was an error in gremlin and he can try to reconnect to titan.

Please @PedroKinetica, @amhester, @willcj33 review this.
